### PR TITLE
F checkUpdate() panic

### DIFF
--- a/main.go
+++ b/main.go
@@ -277,6 +277,13 @@ func handleClientSignal() {
 }
 
 func checkUpdate() {
+	defer func(){
+		if err:=recover();err!=nil{
+			println("Check failed")
+			fmt.Printf("Check error: %+v\n",err)
+			return
+		}
+	}()
 	resp, err := http.Get("https://api.github.com/repos/zhenorzz/goploy/releases/latest")
 	if err != nil {
 		println("Check failed")

--- a/main.go
+++ b/main.go
@@ -277,13 +277,6 @@ func handleClientSignal() {
 }
 
 func checkUpdate() {
-	defer func(){
-		if err:=recover();err!=nil{
-			println("Check failed")
-			fmt.Printf("Check error: %+v\n",err)
-			return
-		}
-	}()
 	resp, err := http.Get("https://api.github.com/repos/zhenorzz/goploy/releases/latest")
 	if err != nil {
 		println("Check failed")
@@ -303,7 +296,11 @@ func checkUpdate() {
 		println(err.Error())
 		return
 	}
-	tagName := result["tag_name"].(string)
+	tagName, ok := result["tag_name"].(string)
+	if !ok {
+		println("Check failed")
+		return
+	}
 	tagVer, err := version.NewVersion(tagName)
 	if err != nil {
 		println("Check version error")


### PR DESCRIPTION
    When the API requested in the checkupdate() method reaches the upper limit of github, the interface {} obtained by result["tag_name"] is nil, which causes the .(string) type assertion to fail, and the thread panic causes the main thread to exit. 
    So I added an exception catch for the child thread to ensure that the main thread runs normally