### PR TITLE
fix special character in cmd

### DIFF
--- a/internal/model/project_server.go
+++ b/internal/model/project_server.go
@@ -6,6 +6,7 @@ package model
 
 import (
 	"fmt"
+
 	sq "github.com/Masterminds/squirrel"
 	"github.com/zhenorzz/goploy/internal/pkg"
 )
@@ -187,22 +188,22 @@ func (ps ProjectServer) ToSSHOption() string {
 	if ps.Server.JumpIP != "" {
 		if ps.Server.JumpPath != "" {
 			if ps.Server.JumpPassword != "" {
-				proxyCommand = fmt.Sprintf("-o ProxyCommand='sshpass -p %s -P assphrase ssh -o StrictHostKeyChecking=no -W %%h:%%p -i %s -p %d %s@%s' ", ps.Server.JumpPassword, ps.Server.JumpPath, ps.Server.JumpPort, ps.Server.JumpOwner, ps.Server.JumpIP)
+				proxyCommand = fmt.Sprintf(`-o ProxyCommand='sshpass -p "%s" -P assphrase ssh -o StrictHostKeyChecking=no -W %%h:%%p -i %s -p %d %s@%s' `, ps.Server.JumpPassword, ps.Server.JumpPath, ps.Server.JumpPort, ps.Server.JumpOwner, ps.Server.JumpIP)
 			} else {
 				proxyCommand = fmt.Sprintf("-o ProxyCommand='ssh -o StrictHostKeyChecking=no -W %%h:%%p -i %s -p %d %s@%s' ", ps.Server.JumpPath, ps.Server.JumpPort, ps.Server.JumpOwner, ps.Server.JumpIP)
 			}
 		} else {
-			proxyCommand = fmt.Sprintf("-o ProxyCommand='sshpass -p %s ssh -o StrictHostKeyChecking=no -W %%h:%%p -p %d %s@%s' ", ps.Server.JumpPassword, ps.Server.JumpPort, ps.Server.JumpOwner, ps.Server.JumpIP)
+			proxyCommand = fmt.Sprintf(`-o ProxyCommand='sshpass -p "%s" ssh -o StrictHostKeyChecking=no -W %%h:%%p -p %d %s@%s' `, ps.Server.JumpPassword, ps.Server.JumpPort, ps.Server.JumpOwner, ps.Server.JumpIP)
 		}
 	}
 	if ps.Server.Path != "" {
 		if ps.Server.Password != "" {
-			return fmt.Sprintf("sshpass -p %s -P assphrase ssh -o StrictHostKeyChecking=no %s -p %d -i %s", ps.Server.Password, proxyCommand, ps.Server.Port, ps.Server.Path)
+			return fmt.Sprintf(`sshpass -p "%s" -P assphrase ssh -o StrictHostKeyChecking=no %s -p %d -i %s`, ps.Server.Password, proxyCommand, ps.Server.Port, ps.Server.Path)
 		} else {
 			return fmt.Sprintf("ssh -o StrictHostKeyChecking=no %s -p %d -i %s", proxyCommand, ps.Server.Port, ps.Server.Path)
 		}
 	} else {
-		return fmt.Sprintf("sshpass -p %s ssh -o StrictHostKeyChecking=no %s -p %d", ps.Server.Password, proxyCommand, ps.Server.Port)
+		return fmt.Sprintf(`sshpass -p "%s" ssh -o StrictHostKeyChecking=no %s -p %d`, ps.Server.Password, proxyCommand, ps.Server.Port)
 	}
 }
 


### PR DESCRIPTION
文件：internal/model/project_server.go
方法：ToSSHOption
当密码里包含特殊字符时，rsync 执行不成功。错误密码示例：JAYQ=&d6{cB?U'0$
以下为标准错误输出
```sh
err: exit status 1
output: Missing trailing-' in remote-shell command.
rsync error: syntax or usage error (code 1) at main.c(432) [sender=3.1.2]
```